### PR TITLE
Add vertical Activity Bar with theme toggle and language switcher placeholders

### DIFF
--- a/frontend/src/components/sidebar/presentations/ActivityBar.jsx
+++ b/frontend/src/components/sidebar/presentations/ActivityBar.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Layout } from 'antd';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSun, faCog } from '@fortawesome/free-solid-svg-icons';
+
+const { Sider } = Layout;
+
+const ActivityBar = () => (
+  <Sider
+    width={60}
+    style={{
+      height: '100vh',
+      position: 'fixed',
+      left: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.03)',
+      textAlign: 'center',
+      paddingBottom: '12px',
+    }}
+  >
+    <div
+      style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        gap: '20px',
+        paddingBottom: '20px',
+      }}
+    >
+      {/* Theme toggle button */}
+      <button
+        type="button"
+        onClick={() => {}}
+        style={{
+          borderRadius: '50%',
+          width: '40px',
+          height: '40px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '1.2rem',
+          backgroundColor: 'rgba(0, 0, 0, 0.03)',
+          border: '1px solid #001529',
+          color: '#001529',
+          cursor: 'pointer',
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+        }}
+        title="Toggle Theme"
+        aria-label="Toggle Theme"
+      >
+        <FontAwesomeIcon icon={faSun} />
+      </button>
+
+      {/* Language switcher */}
+      <select
+        onChange={() => {}}
+        defaultValue="en"
+        style={{
+          background: '#fff',
+          color: '#001529',
+          border: '1px solid #001529',
+          borderRadius: '4px',
+          padding: '2px',
+          fontSize: '0.8rem',
+          cursor: 'pointer',
+        }}
+        title="Change Language"
+        aria-label="Change Language"
+      >
+        <option value="en">🇺🇸</option>
+        <option value="ko">🇰🇷</option>
+      </select>
+
+      {/* Settings button */}
+      <button
+        type="button"
+        onClick={() => {}}
+        style={{
+          background: 'none',
+          border: 'none',
+          color: '#001529',
+          fontSize: '1.2rem',
+          cursor: 'pointer',
+        }}
+        title="Settings"
+        aria-label="Settings"
+      >
+        <FontAwesomeIcon icon={faCog} />
+      </button>
+    </div>
+  </Sider>
+);
+
+export default ActivityBar;

--- a/frontend/src/components/template/presentations/DefaultTemplate.jsx
+++ b/frontend/src/components/template/presentations/DefaultTemplate.jsx
@@ -24,6 +24,7 @@ import Sidebar from '../../sidebar/containers/Sidebar';
 import Contents from '../../contents/containers/Contents';
 import { loadFromCookie, saveToCookie } from '../../../features/cookie/CookieUtil';
 import logoImage from './logo.png';
+import ActivityBar from '../../sidebar/presentations/ActivityBar';
 
 const {
   Sider, Header, Footer,
@@ -79,6 +80,8 @@ const DefaultTemplate = ({
   return (
     // Main layout covering the entire viewport height
     <Layout hasSider style={{ minHeight: '100vh' }}>
+      {/* ACTIVITY BAR (leftmost) */}
+      <ActivityBar />
 
       {/* SIDEBAR */}
       <Sider
@@ -86,7 +89,7 @@ const DefaultTemplate = ({
         style={{
           height: '100vh',
           position: 'fixed',
-          left: 0,
+          left: 60,
         }}
       >
         <div
@@ -116,13 +119,14 @@ const DefaultTemplate = ({
       {/* CONTENTS */}
       <Layout
         style={{
-          marginLeft: '33vw',
+          marginLeft: 'calc(33vw + 60px)',
           // Ensure the content layout stretches to fill the available height
           display: 'flex',
           flexDirection: 'column',
           minHeight: '100vh',
         }}
       >
+
         <Contents style={{ flex: 1 }} />
 
         <Footer


### PR DESCRIPTION
This pull request introduces a vertical Activity Bar positioned on the left side of the layout.
It includes placeholder icons for the following actions:

- Theme Toggle
- Language Switcher
- Settings

Please note that all buttons are currently non-functional and will be implemented in future pull requests.