### PR TITLE
Change position of dark mode toggle button and implement dark mode switching in ActivityBar

### DIFF
--- a/frontend/src/components/ThemeToggleButton.jsx
+++ b/frontend/src/components/ThemeToggleButton.jsx
@@ -9,9 +9,9 @@ const ThemeToggleButton = ({ className, style }) => {
   const { toggleTheme, theme } = useTheme();
 
   const buttonStyle = {
-    position: 'fixed',
-    top: 10,
-    right: 10,
+    // position: 'fixed',
+    // top: 10,
+    // right: 10,
     zIndex: 2000,
     borderRadius: '50%',
     width: '45px',

--- a/frontend/src/components/contents/presentations/Frames.jsx
+++ b/frontend/src/components/contents/presentations/Frames.jsx
@@ -23,7 +23,7 @@ import ServerConnect from '../../frame/containers/ServerConnectContainer';
 import ServerDisconnect from '../../frame/containers/ServerDisconnectContainer';
 import CypherGraphResult from '../../frame/containers/CypherGraphResultContainers';
 import CypherResult from '../../frame/containers/CypherResultContainers';
-import ThemeToggleButton from '../../ThemeToggleButton';
+// import ThemeToggleButton from '../../ThemeToggleButton';
 import CSV from '../../csv';
 import { setting } from '../../../conf/config';
 import styles from './Frames.module.scss';
@@ -140,7 +140,7 @@ const Frames = ({
 
   return (
     <div className={`container-fluid frame-area pt-3 ${styles.frameScroll}`}>
-      <ThemeToggleButton />
+      {/* <ThemeToggleButton /> */}
       {frames}
     </div>
   );

--- a/frontend/src/components/sidebar/presentations/ActivityBar.jsx
+++ b/frontend/src/components/sidebar/presentations/ActivityBar.jsx
@@ -11,7 +11,7 @@ const ActivityBar = () => (
       position: 'fixed',
       left: 0,
       // background-Color: 'rgba(0, 0, 0, 0.03)',
-      backgroundColor: '#e4e4e4ff',
+      backgroundColor: 'var(--activitybar-bg-color)',
       textAlign: 'center',
       paddingBottom: 12,
     }}
@@ -57,9 +57,9 @@ const ActivityBar = () => (
         onChange={() => {}}
         defaultValue="en"
         style={{
-          background: '#fff',
-          color: '#001529',
-          border: '1px solid #001529',
+          background: 'var(--activitybar-select-bg)',
+          color: 'var(--activitybar-text-color)',
+          border: '1px solid var(--activitybar-text-color)',
           borderRadius: 4,
           padding: 2,
           fontSize: '0.8rem',
@@ -79,7 +79,7 @@ const ActivityBar = () => (
         style={{
           background: 'none',
           border: 'none',
-          color: '#001529',
+          color: 'var(--activitybar-text-color)',
           fontSize: '1.2rem',
           cursor: 'pointer',
         }}

--- a/frontend/src/components/sidebar/presentations/ActivityBar.jsx
+++ b/frontend/src/components/sidebar/presentations/ActivityBar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSun, faCog } from '@fortawesome/free-solid-svg-icons';
+import { faCog } from '@fortawesome/free-solid-svg-icons';
+import ThemeToggleButton from '../../ThemeToggleButton';
 
 const ActivityBar = () => (
   <div
@@ -27,7 +28,7 @@ const ActivityBar = () => (
       }}
     >
       {/* Theme toggle button */}
-      <button
+      {/* <button
         type="button"
         onClick={() => {}}
         style={{
@@ -48,7 +49,8 @@ const ActivityBar = () => (
         aria-label="Toggle Theme"
       >
         <FontAwesomeIcon icon={faSun} />
-      </button>
+      </button> */}
+      <ThemeToggleButton />
 
       {/* Language switcher */}
       <select

--- a/frontend/src/static/style.css
+++ b/frontend/src/static/style.css
@@ -93,7 +93,10 @@
     --disabled-text-color: #999;
     --disabled-bg-color: #f0f0f0;
     --footer-bg-color: #f0f2f5;
-
+    --activitybar-bg-color: #e4e4e4;
+    --activitybar-text-color: #001529;
+    --activitybar-select-bg: #ffffff;
+    --activitybar-button-bg: rgba(0, 0, 0, 0.03);
     /* Dark mode */
     --dark-text: #ffffff;
     --dark-bg: #222430;
@@ -200,6 +203,10 @@ body.dark {
     --disabled-text-color: #666;
     --disabled-bg-color: #2c2c2c;
     --footer-bg-color: #1f1f1f;
+    --activitybar-bg-color: #333333;
+    --activitybar-text-color: #ffffff;
+    --activitybar-select-bg: #444444;
+    --activitybar-button-bg: rgba(255, 255, 255, 0.1);
 }
 body {    
     font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
Replaced the dark mode toggle button with an existing placeholder in the ActivityBar.
Refactored hardcoded colors in the ActivityBar to use CSS variables, enabling proper dark mode switching.