### PR TITLE
Add icons to layout dropdown options

### DIFF
--- a/frontend/src/components/ThemeToggleButton.jsx
+++ b/frontend/src/components/ThemeToggleButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
+import { faMoon, faSun } from '@fortawesome/free-solid-svg-icons';
 import { useTheme } from '../contexts/ThemeContext';
 
 const ThemeToggleButton = ({ className, style }) => {

--- a/frontend/src/components/cytoscape/CypherResultCytoscapeFooter.jsx
+++ b/frontend/src/components/cytoscape/CypherResultCytoscapeFooter.jsx
@@ -28,6 +28,7 @@ import {
   updateLabelColor,
   updateNodeLabelSize,
 } from '../../features/cypher/CypherUtil';
+import CytoscapeLayoutDropdown from './CytoscapeLayoutDropdown';
 
 const CypherResultCytoscapeFooter = ({
   footerData,
@@ -100,29 +101,13 @@ const CypherResultCytoscapeFooter = ({
               style={{ color: 'gray' }}
             />
           </button>
-          <span>
-            {t('footer.layout')}
-            :&nbsp;
-          </span>
-          <select
+          Layout :&nbsp;
+          <CytoscapeLayoutDropdown
+            selectedLayout={cytoscapeLayout}
+            onChange={setCytoscapeLayout}
             id="selectLayout"
-            className="col-2 custom-select custom-select-sm layout-select"
-            defaultValue={cytoscapeLayout}
-            onChange={(e) => [setCytoscapeLayout(e.target.value)]}
-          >
-            <option value="random">{t('footer.layouts.random')}</option>
-            <option value="grid">{t('footer.layouts.grid')}</option>
-            <option value="breadthFirst">{t('footer.layouts.breadthFirst')}</option>
-            <option value="concentric">{t('footer.layouts.concentric')}</option>
-            <option value="cola">{t('footer.layouts.cola')}</option>
-            <option value="cose">{t('footer.layouts.cose')}</option>
-            <option value="coseBilkent">{t('footer.layouts.coseBilkent')}</option>
-            <option value="dagre">{t('footer.layouts.dagre')}</option>
-            <option value="klay">{t('footer.layouts.klay')}</option>
-            <option value="euler">{t('footer.layouts.euler')}</option>
-            <option value="avsdf">{t('footer.layouts.avsdf')}</option>
-            <option value="spread">{t('footer.layouts.spread')}</option>
-          </select>
+            className="col-2"
+          />
         </div>
       );
     }
@@ -140,27 +125,13 @@ const CypherResultCytoscapeFooter = ({
             {' '}
             {t('footer.edges')}
           </div>
-          {t('footer.layout')}
-          :&nbsp;
-          <select
+          Layout :&nbsp;
+          <CytoscapeLayoutDropdown
+            selectedLayout={cytoscapeLayout}
+            onChange={setCytoscapeLayout}
             id="selectLayout"
-            className="col-2 custom-select custom-select-sm layout-select"
-            defaultValue={cytoscapeLayout}
-            onChange={(e) => [setCytoscapeLayout(e.target.value)]}
-          >
-            <option value="random">{t('footer.layouts.random')}</option>
-            <option value="grid">{t('footer.layouts.grid')}</option>
-            <option value="breadthFirst">{t('footer.layouts.breadthFirst')}</option>
-            <option value="concentric">{t('footer.layouts.concentric')}</option>
-            <option value="cola">{t('footer.layouts.cola')}</option>
-            <option value="cose">{t('footer.layouts.cose')}</option>
-            <option value="coseBilkent">{t('footer.layouts.coseBilkent')}</option>
-            <option value="dagre">{t('footer.layouts.dagre')}</option>
-            <option value="klay">{t('footer.layouts.klay')}</option>
-            <option value="euler">{t('footer.layouts.euler')}</option>
-            <option value="avsdf">{t('footer.layouts.avsdf')}</option>
-            <option value="spread">{t('footer.layouts.spread')}</option>
-          </select>
+            className="col-2"
+          />
         </div>
       );
     }
@@ -310,53 +281,26 @@ const CypherResultCytoscapeFooter = ({
               icon={footerExpanded ? faAngleUp : faAngleDown}
             />
           </button>
-          {t('footer.layout')}
-          :&nbsp;
-          <select
+          Layout :&nbsp;
+          <CytoscapeLayoutDropdown
+            selectedLayout={cytoscapeLayout}
+            onChange={setCytoscapeLayout}
             id="selectLayout"
-            className="col-2 custom-select custom-select-sm layout-select"
-            defaultValue={cytoscapeLayout}
-            onChange={(e) => [setCytoscapeLayout(e.target.value)]}
-          >
-            <option value="random">{t('footer.layouts.random')}</option>
-            <option value="grid">{t('footer.layouts.grid')}</option>
-            <option value="breadthFirst">{t('footer.layouts.breadthFirst')}</option>
-            <option value="concentric">{t('footer.layouts.concentric')}</option>
-            <option value="cola">{t('footer.layouts.cola')}</option>
-            <option value="cose">{t('footer.layouts.cose')}</option>
-            <option value="coseBilkent">{t('footer.layouts.coseBilkent')}</option>
-            <option value="dagre">{t('footer.layouts.dagre')}</option>
-            <option value="klay">{t('footer.layouts.klay')}</option>
-            <option value="euler">{t('footer.layouts.euler')}</option>
-            <option value="avsdf">{t('footer.layouts.avsdf')}</option>
-            <option value="spread">{t('footer.layouts.spread')}</option>
-          </select>
+            className="col-2"
+          />
         </div>
       );
     }
     return (
       <div className="d-flex pl-3">
         <div className="mr-auto label pl-3" />
-        <div className="px-1">{t('footer.layout')}</div>
-        <select
+        <div className="px-1">Layout : </div>
+        <CytoscapeLayoutDropdown
+          selectedLayout={cytoscapeLayout}
+          onChange={setCytoscapeLayout}
           id="selectLayout"
-          className="col-2 custom-select custom-select-sm layout-select"
-          defaultValue={cytoscapeLayout}
-          onChange={(e) => [setCytoscapeLayout(e.target.value)]}
-        >
-          <option value="random">{t('footer.layouts.random')}</option>
-          <option value="grid">{t('footer.layouts.grid')}</option>
-          <option value="breadthFirst">{t('footer.layouts.breadthFirst')}</option>
-          <option value="concentric">{t('footer.layouts.concentric')}</option>
-          <option value="cola">{t('footer.layouts.cola')}</option>
-          <option value="cose">{t('footer.layouts.cose')}</option>
-          <option value="coseBilkent">{t('footer.layouts.coseBilkent')}</option>
-          <option value="dagre">{t('footer.layouts.dagre')}</option>
-          <option value="klay">{t('footer.layouts.klay')}</option>
-          <option value="euler">{t('footer.layouts.euler')}</option>
-          <option value="avsdf">{t('footer.layouts.avsdf')}</option>
-          <option value="spread">{t('footer.layouts.spread')}</option>
-        </select>
+          className="col-2"
+        />
       </div>
     );
   };

--- a/frontend/src/components/cytoscape/CytoscapeLayoutDropdown.jsx
+++ b/frontend/src/components/cytoscape/CytoscapeLayoutDropdown.jsx
@@ -6,23 +6,75 @@ import {
   faLink, faBrain, faSitemap, faLayerGroup,
   faRetweet, faCircleNotch, faWifi,
 } from '@fortawesome/free-solid-svg-icons';
+import { useTranslation } from 'react-i18next';
 
-export const layoutOptions = [
-  { label: 'Random', value: 'random', icon: faDice },
-  { label: 'Grid', value: 'grid', icon: faTable },
-  { label: 'Breadth-First', value: 'breadthFirst', icon: faTree },
-  { label: 'Concentric', value: 'concentric', icon: faBullseye },
-  { label: 'Cola', value: 'cola', icon: faAtom },
-  { label: 'Cose', value: 'cose', icon: faLink },
-  { label: 'Cose-Bilkent', value: 'coseBilkent', icon: faBrain },
-  { label: 'Dagre', value: 'dagre', icon: faSitemap },
-  { label: 'Klay', value: 'klay', icon: faLayerGroup },
-  { label: 'Euler', value: 'euler', icon: faRetweet },
-  {
-    label: 'Avsdf', value: 'avsdf', icon: faCircleNotch, spin: true,
-  },
-  { label: 'Spread', value: 'spread', icon: faWifi },
-];
+export const useLayoutOptions = () => {
+  const { t } = useTranslation('cytoscape');
+
+  return [
+    {
+      label: t('footer.layouts.random'),
+      value: 'random',
+      icon: faDice,
+    },
+    {
+      label: t('footer.layouts.grid'),
+      value: 'grid',
+      icon: faTable,
+    },
+    {
+      label: t('footer.layouts.breadthFirst'),
+      value: 'breadthFirst',
+      icon: faTree,
+    },
+    {
+      label: t('footer.layouts.concentric'),
+      value: 'concentric',
+      icon: faBullseye,
+    },
+    {
+      label: t('footer.layouts.cola'),
+      value: 'cola',
+      icon: faAtom,
+    },
+    {
+      label: t('footer.layouts.cose'),
+      value: 'cose',
+      icon: faLink,
+    },
+    {
+      label: t('footer.layouts.coseBilkent'),
+      value: 'coseBilkent',
+      icon: faBrain,
+    },
+    {
+      label: t('footer.layouts.dagre'),
+      value: 'dagre',
+      icon: faSitemap,
+    },
+    {
+      label: t('footer.layouts.klay'),
+      value: 'klay',
+      icon: faLayerGroup,
+    },
+    {
+      label: t('footer.layouts.euler'),
+      value: 'euler',
+      icon: faRetweet,
+    },
+    {
+      label: t('footer.layouts.avsdf'),
+      value: 'avsdf',
+      icon: faCircleNotch,
+      spin: true,
+    },
+    {
+      label: t('footer.layouts.spread'),
+      value: 'spread',
+      icon: faWifi,
+    },
+  ];
+};
 
 const CytoscapeLayoutDropdown = ({
   selectedLayout,
@@ -32,7 +84,7 @@ const CytoscapeLayoutDropdown = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
-
+  const layoutOptions = useLayoutOptions();
   const selectedOption = layoutOptions.find((option) => option.value === selectedLayout);
 
   useEffect(() => {

--- a/frontend/src/components/cytoscape/CytoscapeLayoutDropdown.jsx
+++ b/frontend/src/components/cytoscape/CytoscapeLayoutDropdown.jsx
@@ -1,0 +1,183 @@
+import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faDice, faTable, faTree, faBullseye, faAtom,
+  faLink, faBrain, faSitemap, faLayerGroup,
+  faRetweet, faCircleNotch, faWifi,
+} from '@fortawesome/free-solid-svg-icons';
+
+export const layoutOptions = [
+  { label: 'Random', value: 'random', icon: faDice },
+  { label: 'Grid', value: 'grid', icon: faTable },
+  { label: 'Breadth-First', value: 'breadthFirst', icon: faTree },
+  { label: 'Concentric', value: 'concentric', icon: faBullseye },
+  { label: 'Cola', value: 'cola', icon: faAtom },
+  { label: 'Cose', value: 'cose', icon: faLink },
+  { label: 'Cose-Bilkent', value: 'coseBilkent', icon: faBrain },
+  { label: 'Dagre', value: 'dagre', icon: faSitemap },
+  { label: 'Klay', value: 'klay', icon: faLayerGroup },
+  { label: 'Euler', value: 'euler', icon: faRetweet },
+  {
+    label: 'Avsdf', value: 'avsdf', icon: faCircleNotch, spin: true,
+  },
+  { label: 'Spread', value: 'spread', icon: faWifi },
+];
+
+const CytoscapeLayoutDropdown = ({
+  selectedLayout,
+  onChange,
+  className = '',
+  id = 'selectLayout',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+
+  const selectedOption = layoutOptions.find((option) => option.value === selectedLayout);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleSelect = (option) => {
+    onChange(option.value);
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event, option) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleSelect(option);
+    }
+  };
+
+  return (
+    <div
+      ref={dropdownRef}
+      className={`layout-dropdown ${className} `}
+      style={{ position: 'relative' }}
+    >
+      <button
+        id={id}
+        type="button"
+        className="custom-select custom-select-sm layout-select"
+        onClick={handleToggle}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          padding: '0.25rem 0.5rem',
+          fontSize: '0.875rem',
+          fontWeight: '400',
+          lineHeight: '1.5',
+          color: 'var(--dropdown-text-color)',
+          backgroundColor: 'var(--dropdown-bg-color)',
+          border: '1px solid var(--dropdown-border-color)',
+          borderRadius: '0.25rem',
+          cursor: 'pointer',
+          minWidth: '140px',
+        }}
+      >
+        <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          {selectedOption && (
+            <FontAwesomeIcon
+              icon={selectedOption.icon}
+              spin={selectedOption.spin}
+              style={{ fontSize: '0.875rem' }}
+            />
+          )}
+          {selectedOption?.label || 'Select Layout'}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div
+          className="layout-dropdown-menu"
+          role="listbox"
+          style={{
+            position: 'absolute',
+            bottom: '100%',
+            left: '0',
+            right: '0',
+            zIndex: 1000,
+            backgroundColor: '#fff',
+            border: '1px solid var(--dropdown-border-color)',
+            borderRadius: '0.25rem',
+            boxShadow: 'var(--dropdown-box-shadow)',
+            marginBottom: '0.125rem',
+            // maxHeight: '200px',
+            overflowY: 'auto',
+          }}
+        >
+          {layoutOptions.map((option) => (
+            <div
+              key={option.value}
+              role="option"
+              tabIndex={0}
+              aria-selected={option.value === selectedLayout}
+              className={`layout-dropdown-item ${option.value === selectedLayout ? 'selected' : ''}`}
+              onClick={() => handleSelect(option)}
+              onKeyDown={(e) => handleKeyDown(e, option)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+                padding: '0rem 0.75rem',
+                cursor: 'pointer',
+                fontSize: '0.75rem',
+                color: 'var(--dropdown-text-color)',
+                backgroundColor: option.value === selectedLayout ? 'var(--dropdown-selected-bg)' : 'var(--dropdown-unselected-bg)',
+                borderBottom: 'var(--dropdown-item-border-bottom)',
+                transition: 'background-color 0.15s ease-in-out',
+              }}
+              onMouseEnter={(e) => {
+                if (option.value !== selectedLayout) {
+                  e.target.style.backgroundColor = 'var(--dropdown-hover-bg)';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (option.value !== selectedLayout) {
+                  e.target.style.backgroundColor = 'var(--dropdown-unselected-bg)';
+                }
+              }}
+            >
+              <FontAwesomeIcon
+                icon={option.icon}
+                spin={option.spin}
+                style={{ fontSize: '0.875rem', minWidth: '14px' }}
+              />
+              {option.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+CytoscapeLayoutDropdown.propTypes = {
+  selectedLayout: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  id: PropTypes.string,
+};
+CytoscapeLayoutDropdown.defaultProps = {
+  className: '',
+  id: 'selectLayout',
+};
+
+export default CytoscapeLayoutDropdown;

--- a/frontend/src/static/style.css
+++ b/frontend/src/static/style.css
@@ -96,7 +96,14 @@
     --activitybar-bg-color: #e4e4e4;
     --activitybar-text-color: #001529;
     --activitybar-select-bg: #ffffff;
-    --activitybar-button-bg: rgba(0, 0, 0, 0.03);
+    --activitybar-button-bg: rgba(0, 0, 0, 0.03);    --dropdown-text-color: #495057;
+    --dropdown-bg-color: #ffffff;
+    --dropdown-border-color: #ced4da;
+    --dropdown-box-shadow: 0 -0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+    --dropdown-selected-bg: #e9ecef;
+    --dropdown-unselected-bg: #fff;
+    --dropdown-hover-bg: #f8f9fa;
+    --dropdown-item-border-bottom: 1px solid #eaeaeaff;
     /* Dark mode */
     --dark-text: #ffffff;
     --dark-bg: #222430;
@@ -207,6 +214,14 @@ body.dark {
     --activitybar-text-color: #ffffff;
     --activitybar-select-bg: #444444;
     --activitybar-button-bg: rgba(255, 255, 255, 0.1);
+    --dropdown-text-color: #e0e0e0;
+    --dropdown-bg-color: #1e1e1e;
+    --dropdown-border-color: #3a3a3a;
+    --dropdown-box-shadow: 0 -0.125rem 0.25rem rgba(0, 0, 0, 0.4);
+    --dropdown-selected-bg: #2a2a2a;
+    --dropdown-unselected-bg: #1a1a1a;
+    --dropdown-hover-bg: #333333;
+    --dropdown-item-border-bottom: 1px solid #444;
 }
 body {    
     font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
Replaced the select element with a custom CytoscapeLayoutDropdown component. The dropdown now includes an icon placeholder using FontAwesome SVG icons, which can be easily replaced with custom icons alongside the label in the future.