### PR TITLE
adjust footer bar for full-screen and hide footer

### DIFF
--- a/frontend/src/components/frame/Frame.module.scss
+++ b/frontend/src/components/frame/Frame.module.scss
@@ -74,7 +74,7 @@
   top: 0;
   width: 100vw;
   height: 100vh;
-  z-index: 12;
+  z-index: 1001;   //hiding the footer |  footer z-index is 1000
   display: flex;
   flex-direction: column;
 }
@@ -85,6 +85,8 @@
 
 .FullScreen .NormalChart, .FullScreen .MetaChart {
   flex: 1;
+  height: calc(100vh - 200px) !important;
+  min-height: 0;        /* prevent overflow */
 }
 
 .Chart {


### PR DESCRIPTION
This PR addresses the issue of the footer overlapping the full-screen chart.

Changes included:
- Increased `.FullScreen` z-index from `12` to `1001` so it appears above the footer.
- Set chart height to `calc(100vh - 200px)` and `min-height: 0` to prevent overflow.
- Ensures that the footer is hidden when the frame is in full-screen mode.

This resolves the footer visibility issue when expanding the chart to full screen.
